### PR TITLE
Add temporary new tab page, remove default locale setting from manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>Accomplish</title>
+    </head>
+    <body>
+        In Development
+    </body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,6 @@
     "name": "Accomplish",
     "version": "0.0.0.1",
     "version_name": "0.0.0.1: In Development",
-    "default_locale": "en",
     "description": "Use your New Tab page to stay on top of your goals and deadlines.",
     "chrome_url_overrides":
     {


### PR DESCRIPTION
Add temporary new tab page to sanity check new tab override functionality. 

Remove default locale setting from manifest.json, requires some additional work. Let's keep locale in mind but not overengineer this yet.